### PR TITLE
First pass at an FAQ page

### DIFF
--- a/faq/index.hbs
+++ b/faq/index.hbs
@@ -1,0 +1,62 @@
+---
+title: "FAQ"
+tracked_title: FAQ
+description: "Aptible's frequently asked questions"
+posted: 2015-07-21
+section: FAQ
+
+faq:
+  - section: Company
+    section_slug: company
+    questions:
+      - question: What does Aptible do?
+        answer: >
+          Aptible is a Platform-as-a-Service built on Amazon Web Services.
+          We have two core products: Our deployment platform helps your operations
+          engineers scale modern web architecture in secure, private, PHI-ready
+          cloud environments. Our compliance platform provides comprehensive risk,
+          security, and HIPAA compliance management.
+
+  - section: Pricing
+    section_slug: pricing
+    questions:
+      - question: What's a container?
+        answer: >
+          The 1GB refers to the RAM per container. Both the platform and managed
+          accounts include six containers. Typically customers use different
+          containers for applications, databases, etc. With the Docker deployment
+          model, you can scale any application across multiple containers very
+          easily. At the Managed tier, we customize the specifications of your
+          containers but most customers don't need this.
+
+      - question: What about lock-in?
+        answer: >
+          Aptible is designed around open source and engineering best practices.
+          Configuring your app to deploy can be as easy as adding a single, one-line
+          file to your repo. We never require you to build to a proprietary API
+          that may disappear overnight. It's as easy to move your code elsewhere
+          as it is to [on-board]('#hello').
+---
+
+<div class="faq">
+  <div class="container main-content">
+    <div class="row section">
+      <div class="col-md-3 col-sm-3">
+        <div class="list-group">
+        {{#withSort faq "section" }}
+          <a href="#{{section_slug}}" class="list-group-item">{{section}}</a>
+        {{/withSort}}
+        </div>
+      </div>
+      <div class="col-md-7 col-md-offset-1 col-sm-9">
+        {{#withSort faq "section" }}
+          <h1 id="{{section_slug}}">{{section}}</h1>
+          {{#each questions}}
+            <h3>{{question}}</h3>
+            {{#markdown}}{{answer}}{{/markdown}}
+          {{/each}}
+        {{/withSort}}
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
![faq-demo](https://cloud.githubusercontent.com/assets/94830/8826927/ce18749a-3057-11e5-8c90-11376ab81c37.gif)

First pass at an FAQ page. @samyount will give you something to work with.
**CC:** @chasballew, @sandersonet 

- Nothing links _to_ the FAQ, but you can visit /faq to see it in action once I push my apitible.com branch to staging.
- Scroll animation, but no scroll to top on this pass. We can add that.
- I left the short question out. We'll need to solve this another way or adjust this layout to allow for really long questions.
- @samyount: I expect you'll remove the sample Q/As I put in. I wanted to have something to test the scroll.

#### TODO
- Scroll to top
- second pass on layout and UX

#### Ideas for the next pass
- Possibly fix position the left column (so the user doesn't need to scroll to top to get to another question)
- Consider accordian expand / collapse to list questions in the larger column coupled with their answers, so the user clicks to the section, sees all the questions and clicks one to see the answer