### PR TITLE
Aptible badges discount promotion on the pricing page

### DIFF
--- a/company/resources/index.hbs
+++ b/company/resources/index.hbs
@@ -75,7 +75,7 @@ press:
 
 
 <div class="container">
-  <div class="row section hipaa-badges">
+  <div class="row section hipaa-badges" id="hipaa-badges-section">
     <div class="col-md-10 col-md-offset-1 col-sm-12">
       <h2 class="section-title">HIPAA-Compliant. Powered by Aptible.</h2>
       <div class="intro-body">Feel free to use these badges on your site.  We suggest linking the image to <a href="https://www.aptible.com">aptible.com</a>.</div>

--- a/pricing/index.hbs
+++ b/pricing/index.hbs
@@ -47,9 +47,19 @@ tooltip:
 
 needs_more:
   title: Scale much?
-  body: All Aptible services scale on demand at the unit price rates below. High volume plans and custom container RAM sizes are available. 
+  body: All Aptible services scale on demand at the unit price rates below. High volume plans and custom container RAM sizes are available.
   cta: Contact Us
   cta_url: /company/contact
+
+discount:
+  title: Advertise your HIPAA compliance.
+  body: |
+    Add a [Powered by Aptible Badge](/company/resources/#hipaa-badges-section)
+    on your site footer and get a __$100/month discount__.
+
+    Open a
+    [support ticket](https://support.aptible.com/contact) to let us know you
+    are participating.
 
 pricing:
   container: $0.08/hour
@@ -129,15 +139,25 @@ questions:
   <div class="row section">
     <h2 class="section-title">{{plans_title}}</h2>
     {{> pricing_calculator}}
-    <div class="row">
-      <div class="col-xs-12 unit-pricing">
-        <h2 class="section-title">Unit Pricing</h2>
-        <ul class="plan-attributes">
-          <li><strong>1 GB App/Database Containers:</strong> {{pricing.container}}</li>
-          <li><strong>Encrypted Disk:</strong> {{pricing.disk}}</li>
-          <li><strong>Domains:</strong> {{pricing.domain}}</li>
-        </ul>
+  </div>
+
+  <div class="row section">
+    <div class="col-xs-12 unit-pricing">
+      <h2 class="section-title">{{discount.title}}</h2>
+      <div class="intro-body text-center">
+        {{#markdown}}{{discount.body}}{{/markdown}}
       </div>
+    </div>
+  </div>
+
+  <div class="row section">
+    <div class="col-xs-12 unit-pricing">
+      <h2 class="section-title">Unit Pricing</h2>
+      <ul class="plan-attributes">
+        <li><strong>1 GB App/Database Containers:</strong> {{pricing.container}}</li>
+        <li><strong>Encrypted Disk:</strong> {{pricing.disk}}</li>
+        <li><strong>Domains:</strong> {{pricing.domain}}</li>
+      </ul>
     </div>
   </div>
 


### PR DESCRIPTION
![badges](https://cloud.githubusercontent.com/assets/94830/9009198/cd50d58c-375c-11e5-9bc0-37366e9ba22a.gif)

Closes https://github.com/aptible/aptible-pages/issues/25

- Adds the “Adverise you HIPAA compliance” section to the pricing page.
- Adds an anchor Id to the HIPAA badge section on the resources page
for direct linking

Good to go, but I wonder if there isn’t too much white space on the sections below the pricing calculator.

We may also want to add the discount information on the resource page with a link to the support ticket form.