### PR TITLE
Missed this in the last update

### DIFF
--- a/compliance/index.hbs
+++ b/compliance/index.hbs
@@ -4,8 +4,8 @@ tracked_title: HIPAA Compliance for Digital Health
 sub_title: Compliance tools with code-level integration
 id: compliance content-page
 images:
-  risk_testimonial: /pages/assets/compliance/jim-boss.png
-  training_testimonial: /pages/assets/compliance/jim-boss.png
+  risk_testimonial: /pages/assets/compliance/ian.png
+  training_testimonial: /pages/assets/compliance/ian.png
   social_kp: /pages/assets/compliance/compliance-logo-kp.png
   social_va: /pages/assets/compliance/compliance-logo-va.png
   social_md: /pages/assets/compliance/compliance-logo-md.png


### PR DESCRIPTION
Updated both testimonials with the Ian image. I didn't see this at the top in the `images:` section. Maybe we should move the testimonial images next to the testimonial copy. What do you think @samyount?