### PR TITLE
Pricing Page Updates

### DIFF
--- a/pricing/index.hbs
+++ b/pricing/index.hbs
@@ -6,11 +6,6 @@ description: "Aptible plans and pricing"
 posted: 2015-12-10
 production_title: Aptible Production Account
 
-hero_title: Try Aptible now with a Development Account
-hero_sub_title: No commitment, no risk.
-hero_cta: Open a Development Account
-hero_url: https://dashboard.aptible.com/signup?plan=development
-
 plans_title: Explore Plans and Pricing
 
 step1_title: About You
@@ -68,6 +63,15 @@ pricing:
   disk: $0.37/GB/month
   domain: $0.05/hour
 
+support_plans:
+  title: Premium Support
+  body: |
+    **Need help?** Aptible's Support and Customer Success teams are ready.
+
+    **Need more?** VPN and architecture support add-ons, account specific
+    slack channels, and dedicated support engineers are available.
+  cta: See Support Plans
+
 unique_situation:
   title: Need something special?
   sub_title: Custom container RAM sizes, optimized EC2 instance types, and high volume plans are available.
@@ -76,7 +80,7 @@ unique_situation:
 
 intro_credit: $500
 
-pricing_cta: Request a Quote
+pricing_cta: Get Started Now
 
 quick_start:
   - name: Ruby
@@ -111,22 +115,12 @@ quick_start:
 ---
 
 <div class="container">
-  <div class="row section bordered callout-section">
-    <div class="col-md-10 col-md-offset-1 col-sm-12 our-philosophy">
-      <h2 class="callout-title">{{hero_title}}</h2>
-      <div class="callout-body">{{hero_sub_title}}</div>
-      <div class="callout-cta">
-        <a href="{{hero_url}}" class="btn btn-lg btn-primary">{{hero_cta}}</a>
-      </div>
-    </div>
-  </div>
-
-  <div class="row section">
+  <div class="row section bordered">
     <h2 class="section-title">{{plans_title}}</h2>
     {{> pricing_calculator}}
   </div>
 
-  <div class="row section">
+  <div class="row section bordered">
     <div id="unit-pricing" class="col-xs-12 unit-pricing">
       <h2 class="section-title">Unit Pricing</h2>
       <ul class="plan-attributes">
@@ -135,6 +129,16 @@ quick_start:
         <li><strong>Encrypted Disk:</strong> {{pricing.disk}}</li>
         <li><strong>Domains:</strong> {{pricing.domain}}</li>
       </ul>
+    </div>
+  </div>
+
+  <div class="row section bordered">
+    <div class="col-xs-12 text-hero">
+      <h2 class="section-title">{{support_plans.title}}</h2>
+      <div class="text-hero__sub-title">
+        {{#markdown}}{{support_plans.body}}{{/markdown}}
+      </div>
+      <a href="/support" class="btn btn-primary btn-lg">{{support_plans.cta}}</a>
     </div>
   </div>
 

--- a/pricing/index.hbs
+++ b/pricing/index.hbs
@@ -64,13 +64,8 @@ pricing:
   domain: $0.05/hour
 
 support_plans:
-  title: Premium Support
-  body: |
-    **Need help?** Aptible's Support and Customer Success teams are ready.
-
-    **Need more?** VPN and architecture support add-ons, account specific
-    slack channels, and dedicated support engineers are available.
-  cta: See Support Plans
+  title: Support Plans
+  cta: Learn More
 
 unique_situation:
   title: Need something special?
@@ -135,8 +130,34 @@ quick_start:
   <div class="row section bordered">
     <div class="col-xs-12 text-hero">
       <h2 class="section-title">{{support_plans.title}}</h2>
-      <div class="text-hero__sub-title">
-        {{#markdown}}{{support_plans.body}}{{/markdown}}
+      <div class="row">
+        <div class="col-xs-12 col-md-4 support-plan-summary">
+          <h4>Business</h4>
+          <ul>
+            <li>Normal severity response times in 12 hours or less</li>
+            <li>Email and portal channels</li>
+            <li>Included with every account</li>
+          </ul>
+        </div>
+        <div class="col-xs-12 col-md-4 support-plan-summary">
+          <h4>Premium</h4>
+          <ul>
+            <li>Dedicated slack channel</li>
+            <li>Urgent severity response times in 1 hour or less</li>
+            <li>Administrative portal access to manage tickets</li>
+            <li>Email, portal, and slack channels</li>
+          </ul>
+        </div>
+        <div class="col-xs-12 col-md-4 support-plan-summary">
+          <h4>Enterprise</h4>
+          <ul>
+            <li>Dedicated Support Engineer</li>
+            <li>Dedicated Technical Account Manager</li>
+            <li>Critical issue response times in 15 minutes or less</li>
+            <li>Included base VPN and architecture support</li>
+            <li>Email, portal, slack, and phone channels</li>
+          </ul>
+        </div>
       </div>
       <a href="/support" class="btn btn-primary btn-lg">{{support_plans.cta}}</a>
     </div>


### PR DESCRIPTION
- clarify pricing CTA (@shahkader) "Get Started Now" replaces "Request A Quote"
<img width="354" alt="screen shot 2016-02-06 at 7 26 52 am" src="https://cloud.githubusercontent.com/assets/94830/12867479/dc4265b0-cca3-11e5-9530-7a30d5809d3d.png">
- remove top CTA section (@chasballew)
- support plan section (@chasballew, @shahkader)

**Note:** You can update the support plan title, copy, and CTA button text in the YAML front-matter. I got something in there to start with.
<img width="996" alt="screen shot 2016-02-06 at 7 26 36 am" src="https://cloud.githubusercontent.com/assets/94830/12867478/d50ecd7e-cca3-11e5-9c00-3b930810a523.png">

Will wait for a review on this.